### PR TITLE
feat(gateway): add github emojis route and version middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .wrangler
 dist
+.dev.vars

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { apiReference } from "@scalar/hono-api-reference";
 import { env } from "hono/adapter";
 import { showRoutes } from "hono/dev";
 import { HTTPException } from "hono/http-exception";
+
+import { GATEWAY_GITHUB_ROUTER } from "./routes/gateway_github";
 import { V1_CATEGORIES_ROUTER } from "./routes/v1_categories";
 import { V1_VERSIONS_ROUTER } from "./routes/v1_versions";
 
@@ -11,6 +13,7 @@ const app = new OpenAPIHono<HonoContext>();
 
 app.route("/", V1_VERSIONS_ROUTER);
 app.route("/", V1_CATEGORIES_ROUTER);
+app.route("/", GATEWAY_GITHUB_ROUTER);
 
 app.get(
   "/scalar",
@@ -20,10 +23,6 @@ app.get(
     },
     layout: "classic",
     customCss: /* css */`
-    .tag-section {
-      padding: 0 !important;
-    }
-
     .endpoint-label-path {
       display: none !important;
     }
@@ -35,6 +34,7 @@ app.get(
     .scalar-codeblock-code {
       display: unset;
     }
+
 
     :root {
       --theme-color-accent: rgb(59, 130, 246);
@@ -82,6 +82,10 @@ app.doc("/openapi.json", (c) => {
       {
         name: "Versions",
         description: "Emoji versions related endpoints",
+      },
+      {
+        name: "Gateway",
+        description: "Gateway related endpoints",
       },
     ],
     servers: [

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -1,6 +1,8 @@
 import { createMiddleware } from "hono/factory";
 import { createError, getAvailableVersions } from "../utils";
 
+const DEFAULT_FALLBACK_VERSION = "15.1";
+
 export const versionMiddleware = createMiddleware(async (c, next) => {
   const version = c.req.param("version");
   const fullPath = c.req.path;
@@ -9,6 +11,7 @@ export const versionMiddleware = createMiddleware(async (c, next) => {
     return createError(c, 400, "missing version");
   }
 
+  // TODO(@luxass): cache the available versions for x amount of time.
   const availableVersions = await getAvailableVersions();
 
   if (version !== "latest" && !availableVersions.some((v) => v.emoji_version === version)) {
@@ -23,7 +26,7 @@ export const versionMiddleware = createMiddleware(async (c, next) => {
       return createError(c, 404, "no versions available");
     }
 
-    const path = fullPath.replace("latest", latestVersion.emoji_version ?? "15.1");
+    const path = fullPath.replace("latest", latestVersion.emoji_version ?? DEFAULT_FALLBACK_VERSION);
 
     return c.redirect(path);
   }

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -1,0 +1,32 @@
+import { createMiddleware } from "hono/factory";
+import { createError, getAvailableVersions } from "../utils";
+
+export const versionMiddleware = createMiddleware(async (c, next) => {
+  const version = c.req.param("version");
+  const fullPath = c.req.path;
+
+  if (version == null) {
+    return createError(c, 400, "missing version");
+  }
+
+  const availableVersions = await getAvailableVersions();
+
+  if (version !== "latest" && !availableVersions.some((v) => v.emoji_version === version)) {
+    return createError(c, 404, "version not found");
+  }
+
+  if (version === "latest") {
+    // redirect to the latest version, that isn't a draft.
+    const latestVersion = availableVersions.find((v) => !v.draft);
+
+    if (latestVersion == null) {
+      return createError(c, 404, "no versions available");
+    }
+
+    const path = fullPath.replace("latest", latestVersion.emoji_version ?? "15.1");
+
+    return c.redirect(path);
+  }
+
+  await next();
+});

--- a/src/routes/gateway_github.openapi.ts
+++ b/src/routes/gateway_github.openapi.ts
@@ -1,0 +1,28 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { ApiErrorSchema } from "../schemas";
+
+export const GITHUB_EMOJIS_ROUTE = createRoute({
+  method: "get",
+  path: "/emojis",
+  tags: ["Gateway"],
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.record(z.string()).openapi({
+            description: "A list of all GitHub emojis available",
+          }),
+        },
+      },
+      description: "Retrieve a list of all GitHub emojis",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+  },
+});

--- a/src/routes/gateway_github.ts
+++ b/src/routes/gateway_github.ts
@@ -1,0 +1,27 @@
+import type { HonoContext } from "../types";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { cache, createError } from "../utils";
+import { GITHUB_EMOJIS_ROUTE } from "./gateway_github.openapi";
+
+export const GATEWAY_GITHUB_ROUTER = new OpenAPIHono<HonoContext>().basePath("/api/gateway/github");
+
+GATEWAY_GITHUB_ROUTER.openapi(GITHUB_EMOJIS_ROUTE, async (c) => {
+  const response = await fetch("https://api.github.com/emojis", {
+    headers: {
+      "Accept": "application/vnd.github.v3+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Authorization": `Bearer ${c.env.GITHUB_TOKEN}`,
+      "User-Agent": "luxass - (api.mojis.dev)",
+    },
+  });
+
+  if (!response.ok) {
+    return createError(c, 500, "Internal Server Error");
+  }
+
+  const emojis = await response.json<Record<string, string>>();
+
+  cache(c, 3600, true);
+
+  return c.json(emojis, 200);
+});

--- a/src/routes/gateway_github.ts
+++ b/src/routes/gateway_github.ts
@@ -16,6 +16,9 @@ GATEWAY_GITHUB_ROUTER.openapi(GITHUB_EMOJIS_ROUTE, async (c) => {
   });
 
   if (!response.ok) {
+    const errorData = await response.text();
+    console.error(`GitHub API error: ${response.status} - ${errorData}`);
+
     return createError(c, 500, "Internal Server Error");
   }
 

--- a/src/routes/v1_categories.ts
+++ b/src/routes/v1_categories.ts
@@ -1,40 +1,13 @@
 import type { HonoContext } from "../types";
 import { OpenAPIHono, z } from "@hono/zod-openapi";
+import { versionMiddleware } from "../middlewares/version";
 import { EmojiCategorySchema } from "../schemas";
-import { createError, getAvailableVersions } from "../utils";
+import { createError } from "../utils";
 import { ALL_CATEGORIES_ROUTE, GET_CATEGORY_ROUTE } from "./v1_categories.openapi";
 
 export const V1_CATEGORIES_ROUTER = new OpenAPIHono<HonoContext>().basePath("/api/v1/categories/:version");
 
-V1_CATEGORIES_ROUTER.use(async (c, next) => {
-  const version = c.req.param("version");
-  const fullPath = c.req.path;
-
-  if (version == null) {
-    return createError(c, 400, "missing version");
-  }
-
-  const availableVersions = await getAvailableVersions();
-
-  if (version !== "latest" && !availableVersions.some((v) => v.emoji_version === version)) {
-    return createError(c, 404, "version not found");
-  }
-
-  if (version === "latest") {
-    // redirect to the latest version, that isn't a draft.
-    const latestVersion = availableVersions.find((v) => !v.draft);
-
-    if (latestVersion == null) {
-      return createError(c, 404, "no versions available");
-    }
-
-    const path = fullPath.replace("latest", latestVersion.emoji_version ?? "15.1");
-
-    return c.redirect(path);
-  }
-
-  await next();
-});
+V1_CATEGORIES_ROUTER.use(versionMiddleware);
 
 V1_CATEGORIES_ROUTER.openapi(ALL_CATEGORIES_ROUTE, async (c) => {
   const version = c.req.param("version");

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface HonoContext {
   Bindings: {
     ENVIRONMENT: string;
     API_VERSION?: string;
+    GITHUB_TOKEN: string;
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,15 @@ export async function getAvailableVersions(): Promise<EmojiLock["versions"]> {
 
   return result.data.versions;
 }
+
+export function cache<TCtx extends Context>(ctx: TCtx, age: number, immutable = false) {
+  if (age === -1) {
+    ctx.header("Expires", "0");
+    ctx.header("Pragma", "no-cache");
+    ctx.header("Cache-Control", "no-cache, no-store, must-revalidate");
+    return;
+  }
+
+  ctx.header("Expires", new Date(Date.now() + age * 1000).toUTCString());
+  ctx.header("Cache-Control", ["public", `max-age=${age}`, immutable ? "immutable" : null].filter((x) => !!x).join(", "));
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new gateway API endpoint for GitHub integrations, including a route to retrieve GitHub emojis.
  - Enhanced API documentation with an additional category for gateway-related endpoints.
  - Improved version handling for API requests, ensuring clear error responses and proper redirection when needed.

- **Chores**
  - Updated repository configuration to ignore local development variables.
  - Implemented an enhanced caching mechanism to optimize response delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->